### PR TITLE
Downgrade cats-effect to 3.4.x

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -24,9 +24,9 @@ ThisBuild / tlJdkRelease := Some(8)
 ThisBuild / testFrameworks += new TestFramework("munit.Framework")
 
 val catsV = "2.9.0"
-val catsEffectV = "3.5.0"
-val fs2V = "3.7.0"
-val http4sV = "0.23.19"
+val catsEffectV = "3.4.11"
+val fs2V = "3.6.1"
+val http4sV = "0.23.18"
 val fiberLocalV = "0.1.2"
 val natchezV = "0.3.2"
 val munitCatsEffectV = "2.0.0-M3"


### PR DESCRIPTION
Hello again! I'm working on some services upgrades and I am still getting errors updating to `cats-effect` 3.5.x. I would like to decouple the non-breaking `cats-effect` upgrade from the breaking `natchez` upgrade, so that I can update the latter without upgrading the former.

This PR downgrades cats-effect so that services can pull in the latest version without pulling in `cats-effect` 3.5.x. Projects that depend on this library can still opt in to `cats-effect` 3.5.x, but if they don't they won't be forced into it.

The disadvantage to doing this is that it no longer bundles the `cats-effect`, `fs2`, and  `http4s` versions. This could theoretically break somebody if they depend on the latest version of this library but are behind in others. I think this is a reasonable tradeoff since there are potentially other libraries in the ecosystem which aren't ready anyway, even if all I'm seeing is what's fixed in https://github.com/typelevel/fs2/pull/3238.